### PR TITLE
Fix the API type curriculum header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.pnpm-debug.log
 node_modules

--- a/services/website/src/lib/components/byoc/index.svelte
+++ b/services/website/src/lib/components/byoc/index.svelte
@@ -533,7 +533,7 @@
   {/if}
 
   {#if sectionToShow === "apitype"}
-    <Section title="2. Select a type of styling">
+    <Section title="3. Select a type of API">
       {#each Object.keys(curriculumConfiguration.web[$curriculumSelections.web].apitype) as name}
         <Module layer="apitype" name="{name}" />
       {/each}


### PR DESCRIPTION
Close #35.

<a href="https://gitpod.io/#https://github.com/WebstoneHQ/platform/pull/36"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

